### PR TITLE
clientVersion 값과 신속항원검사 결과 입력 기능 추가

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,4 +1,4 @@
-from hcskr.hcskr import selfcheck
+from hcskr.hcskr import selfcheck, QuickTestResult
 
 name = input("이름을 입력하세요: ")
 birth = input("생년월일을 입력하세요: ")
@@ -6,6 +6,7 @@ level = input("학교종류를 입력하세요(예: 초등학교, 중학교, 고
 region = input("지역을 입력하세요(예: 서울, 경기, 전남....): ")
 school = input("학교이름을 입력하세요(예: 두둥실고): ")
 password = input("비밀번호를 입력하세요: ")
-data = selfcheck(name,birth,region,school,level,password)
+quickTestResult = input("신속항원검사 결과를 입력하세요(none, negative, positive): ")
+data = selfcheck(name,birth,region,school,level,password, quickTestResult=QuickTestResult(quickTestResult))
 
 print(data['message'])

--- a/example.py
+++ b/example.py
@@ -7,6 +7,6 @@ region = input("지역을 입력하세요(예: 서울, 경기, 전남....): ")
 school = input("학교이름을 입력하세요(예: 두둥실고): ")
 password = input("비밀번호를 입력하세요: ")
 quickTestResult = input("신속항원검사 결과를 입력하세요(none, negative, positive): ")
-data = selfcheck(name,birth,region,school,level,password, quickTestResult=QuickTestResult(quickTestResult))
+data = selfcheck(name,birth,region,school,level,password, quicktestresult=QuickTestResult(quickTestResult))
 
 print(data['message'])

--- a/hcskr/__init__.py
+++ b/hcskr/__init__.py
@@ -11,4 +11,5 @@ __all__ = [
     "userlogin",
     "tokenselfcheck",
     "generatetoken",
+    "QuickTestResult"
 ]

--- a/hcskr/hcskr.py
+++ b/hcskr/hcskr.py
@@ -326,7 +326,6 @@ async def asyncUserLogin(
             },
             session=session,
         )
-        print(res)
 
         if "isError" in res:
             return {

--- a/hcskr/hcskr.py
+++ b/hcskr/hcskr.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import sys
 from base64 import b64decode, b64encode
+from enum import Enum
 
 import aiohttp
 import jwt
@@ -9,6 +10,12 @@ import jwt
 from .mapping import encrypt, pubkey, schoolinfo
 from .request import search_school, send_hcsreq
 from .transkey import mTransKey
+
+
+class QuickTestResult(Enum):
+    none = "none"
+    negative = "negative"
+    positive = "positive"
 
 
 def selfcheck(
@@ -19,10 +26,11 @@ def selfcheck(
     level: str,
     password: str,
     customloginname: str = None,
+    quicktestresult: QuickTestResult = QuickTestResult.negative,
     loop=asyncio.get_event_loop(),
 ):
     return loop.run_until_complete(
-        asyncSelfCheck(name, birth, area, schoolname, level, password, customloginname)
+        asyncSelfCheck(name, birth, area, schoolname, level, password, customloginname, quicktestresult)
     )
 
 
@@ -83,6 +91,7 @@ async def asyncSelfCheck(
     level: str,
     password: str,
     customloginname: str = None,
+    quicktestresult: QuickTestResult = QuickTestResult.negative
 ):
     async with aiohttp.ClientSession() as session:
         if customloginname is None:
@@ -146,12 +155,14 @@ async def asyncSelfCheck(
                 json={
                     "rspns01": "1",
                     "rspns02": "1",
-                    "rspns03": "1",
+                    "rspns03": "1" if quicktestresult == QuickTestResult.none else None,
+                    "rspns07": None if quicktestresult == QuickTestResult.none else "0" if quicktestresult == QuickTestResult.negative else '1',
                     "rspns08": "0",
                     "rspns09": "0",
                     "rspns00": "Y",
                     "upperToken": token,
                     "upperUserNameEncpt": customloginname,
+                    "clientVersion": "1.8.8"
                 },
                 session=session,
             )


### PR DESCRIPTION
- `selfcheck`와 `asyncSelfcheck` 함수에 `quickTestResult` 인수를 추가했습니다. `QuickTestResult.none / positive / negative`로 넣을 수 있습니다. (파이썬 3.4부터 가능)
- `clientVersion` 값을 `/registerServey`로 자가진단 설문을 제출할 때 넣습니다. 아직 이 값이 어떤 방식으로 작동하는지는 (최신 버전이 아니면 - 오류를 내거나, - 하위 호환에 맞게 자동으로 변경하는지) 알 수 없기 때문에 지켜봐야 합니다.

Closes #3.